### PR TITLE
Warn user about open redirects

### DIFF
--- a/controller.rst
+++ b/controller.rst
@@ -184,6 +184,14 @@ For more information, see the :doc:`Routing chapter </routing>`.
 
 .. tip::
 
+    The ``redirect()`` method does not check it's input. If you use user input 
+    directly as it's parameter, you might open up your page to unvalidated 
+    redirects and forwards, which is in the OWASP top 10 of web application 
+    security flaws. For more information, see https://www.owasp.org/index.php/Open_redirect
+
+
+.. tip::
+
     The ``redirectToRoute()`` method is simply a shortcut that creates a
     ``Response`` object that specializes in redirecting the user. It's
     equivalent to::


### PR DESCRIPTION
The `redirect()` method is open to open redirects if user input is directly passed as parameter. This is of course as intended, and most people would know directly passing user input is never wise, but I think that warning developers can not be done enough.

I hope this message is clear, but please let me know of any better wording or if the `tip` context is the right one to use here.
